### PR TITLE
Reset token automatically when expired

### DIFF
--- a/lib/mais_orcid_client/authenticator.rb
+++ b/lib/mais_orcid_client/authenticator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MaisOrcidClient
+  # The namespace for the "login" command
+  class Authenticator
+    attr_reader :client_id, :client_secret, :base_url
+
+    def self.token(client_id, client_secret, base_url)
+      new(client_id, client_secret, base_url).token
+    end
+
+    def initialize(client_id, client_secret, base_url)
+      @client_id = client_id
+      @client_secret = client_secret
+      @base_url = base_url
+    end
+
+    # @return [String]
+    def token
+      client = OAuth2::Client.new(client_id, client_secret, site: base_url,
+        token_url: "/api/oauth/token", authorize_url: "/api/oauth/authorize",
+        auth_scheme: :request_body)
+      client.client_credentials.get_token.token
+    end
+  end
+end

--- a/lib/mais_orcid_client/token_wrapper.rb
+++ b/lib/mais_orcid_client/token_wrapper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MaisOrcidClient
+  # Wraps API operations to request new access token if expired
+  class TokenWrapper
+    def self.refresh(config)
+      yield
+    rescue UnexpectedResponse::UnauthorizedError
+      config.token = Authenticator.token(config.client_id, config.client_secret, config.base_url)
+      yield
+    end
+  end
+end

--- a/lib/mais_orcid_client/unexpected_response.rb
+++ b/lib/mais_orcid_client/unexpected_response.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MaisOrcidClient
+  # Handles unexpected responses when communicating with Mais
+  class UnexpectedResponse
+    # Error raised when the Mais API returns a 401 Unauthorized
+    class UnauthorizedError < StandardError; end
+
+    # Error raised when the Mais API returns a 500 error
+    class ServerError < StandardError; end
+
+    # Error raised when the Mais API returns a response with an error message in it
+    class ResponseError < StandardError; end
+
+    def self.call(response)
+      case response.status
+      when 401
+        raise UnauthorizedError, "There was a problem with the access token: #{response.body}"
+      when 500
+        raise ServerError, "Mais server error: #{response.body}"
+      else
+        raise StandardError, "Unexpected response: #{response.status} #{response.body}"
+      end
+    end
+  end
+end

--- a/spec/mais_orcid_client_spec.rb
+++ b/spec/mais_orcid_client_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe MaisOrcidClient do
     end
 
     context "when server returns 500" do
-      it "raises" do
+      it "raises ServerError" do
         VCR.use_cassette("Mais_Client/_fetch_orcid_users/raises") do
-          expect { orcid_users }.to raise_error("UIT MAIS ORCID User API returned 500")
+          expect { orcid_users }.to raise_error(MaisOrcidClient::UnexpectedResponse::ServerError)
         end
       end
     end
@@ -83,7 +83,9 @@ RSpec.describe MaisOrcidClient do
 
     context "when an orcidid is invalid" do
       it "returns nil" do
-        expect(bogus_orcid_user_by_orcidid).to be_nil
+        VCR.use_cassette("Mais_Client/_fetch_orcid_user/retrieves user") do
+          expect(bogus_orcid_user_by_orcidid).to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

We are seeing recurring instances of OK computer failures for the Mais client after switching to a gemifyed version (from inline code).  Suspect this is because the token has a lifetime of 3600 seconds (based on header information in the response from the authorization call) and the gem version of the client uses a singleton, which currently persists the token indefinitely until the Rails app is restarted and the gem client is reinitialized.

This change borrows from the pattern in the Globus client gem, which auto refreshes the token if we get an unauthorized error (see https://github.com/sul-dlss/globus_client/blob/main/lib/globus_client/token_wrapper.rb)

## How was this change tested? 🤨

Updated specs, and on localhost hitting the actual Mais UAT service, waiting for more than one hour, hitting another call, seeing the new token being set, and the calls continuing to work.  