### PR TITLE
update MaIS URLs and structure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mais_orcid_client (0.4.0)
+    mais_orcid_client (1.0.0)
       activesupport (>= 4.2)
       faraday
       faraday-retry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       faraday
       faraday-retry
       oauth2
+      ostruct
       zeitwerk
 
 GEM
@@ -69,6 +70,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
+    ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.7.2)
       ast (~> 2.4.1)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ For one-off requests:
 require "mais_orcid_client"
 
 # NOTE: The settings below live in the consumer, not in the gem.
+# The user_agent string can be changed by consumers as requested by MaIS for tracking
 client = MaisOrcidClient.configure(
   client_id: Settings.mais_orcid.client_id,
   client_secret: Settings.mais_orcid.client_secret,
   base_url: Settings.mais_orcid.base_url,
   token_url: Settings.mais_orcid.token_url,
-  user_agent: 'some-user-agent-string-to-send-in-requets' # defaults to 'stanford-library-sul-pub'
+  user_agent: 'some-user-agent-string-to-send-in-requests' # defaults to 'stanford-library-sul-pub'
 )
 client.fetch_orcid_user(sunetid: 'nataliex') # get a single user by sunet
 client.fetch_orcid_user(orcid: '0000-1111-2222-3333-4444') # get a single user by orcidid

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ to be sure configuration has already occurred, e.g.:
 MaisOrcidClient.configure(
   client_id: Settings.mais_orcid.client_id,
   client_secret: Settings.mais_orcid.client_secret,
-  base_url: Settings.mais_orcid.base_url
+  base_url: Settings.mais_orcid.base_url,
+  token_url: Settings.mais_orcid.token_url
 )
 
 # app/services/my_mais_orcid_service.rb
@@ -72,6 +73,7 @@ To record new cassettes:
 2. Add your new spec with a new cassette name (or delete a previous cassette to re-create it).
 3. Run just that new spec (important: else previous specs may use cassettes that have redacted credentials, causing your new spec to fail).
 4. You should get a new cassette with the name you specified in the spec.
-5. The cassette should have access tokens and secrets sanitized by the config in `spec_helper.rb`, but you can double check, EXCEPT for user access tokens in the user response.  These should be sanitized manaully (e.g. "access_token":"8d13b8bb-XXXX-YYYY-b7d6-87aecd5a8975")
+5. The cassette should have access tokens and secrets sanitized by the config in `spec_helper.rb`, but you can double check.
 6. Set your configuration at the top of the spec back to the fake client_id and client_secret values.
+7. The spec that checks for a raised exception when fetching all users may need to be handcrafted in the cassette to look it raised a 500.  It's hard to get the actual URL to produce a 500 on this call.
 7. Re-run all the specs - they should pass now without making real calls.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ client = MaisOrcidClient.configure(
   client_id: Settings.mais_orcid.client_id,
   client_secret: Settings.mais_orcid.client_secret,
   base_url: Settings.mais_orcid.base_url
+  token_url: Settings.mais_orcid.token_url
 )
 client.fetch_orcid_user(sunetid: 'nataliex')
 ```

--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ require "mais_orcid_client"
 client = MaisOrcidClient.configure(
   client_id: Settings.mais_orcid.client_id,
   client_secret: Settings.mais_orcid.client_secret,
-  base_url: Settings.mais_orcid.base_url
-  token_url: Settings.mais_orcid.token_url
+  base_url: Settings.mais_orcid.base_url,
+  token_url: Settings.mais_orcid.token_url,
+  user_agent: 'some-user-agent-string-to-send-in-requets' # defaults to 'stanford-library-sul-pub'
 )
-client.fetch_orcid_user(sunetid: 'nataliex')
+client.fetch_orcid_user(sunetid: 'nataliex') # get a single user by sunet
+client.fetch_orcid_user(orcid: '0000-1111-2222-3333-4444') # get a single user by orcidid
+client.fetch_orcid_users # return all users
 ```
 
 You can also invoke methods directly on the client class, which is useful in a

--- a/lib/mais_orcid_client.rb
+++ b/lib/mais_orcid_client.rb
@@ -29,13 +29,15 @@ class MaisOrcidClient
     # @param client_secret [String] the client secret to authenticate with MAIS
     # @param base_url [String] the base URL for the API
     # @param token_url [String] the base token URL for authentication (getting token)
-    def configure(client_id:, client_secret:, base_url:, token_url:)
+    # @param user_agent [String] the user agent to use for requests (default: 'stanford-library-sul-pub')
+    def configure(client_id:, client_secret:, base_url:, token_url:, user_agent: 'stanford-library-sul-pub')
       # rubocop:disable Style/OpenStructUse
       instance.config = OpenStruct.new(
         token: Authenticator.token(client_id, client_secret, token_url),
         client_id:,
         client_secret:,
-        base_url:
+        base_url:,
+        user_agent:
       )
       # rubocop:enable Style/OpenStructUse
 
@@ -135,6 +137,7 @@ class MaisOrcidClient
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def conn
     conn = Faraday.new(url: config.base_url) do |faraday|
       faraday.request :retry, max: 3,
@@ -144,10 +147,11 @@ class MaisOrcidClient
     end
     conn.options.timeout = 500
     conn.options.open_timeout = 10
-    conn.headers[:user_agent] = 'stanford-library-sul-pub'
+    conn.headers[:user_agent] = config.user_agent
     conn.headers[:authorization] = "Bearer #{config.token}"
     conn
   end
+  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
 
   # @param [string] orcidid which can include a full URI, e.g. "https://sandbox.orcid.org/0000-0002-7262-6251"

--- a/lib/mais_orcid_client.rb
+++ b/lib/mais_orcid_client.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'faraday'
 require 'faraday/retry'
 require 'oauth2'
+require 'ostruct'
 require 'singleton'
 require 'zeitwerk'
 
@@ -27,10 +28,11 @@ class MaisOrcidClient
     # @param client_id [String] the client identifier registered with MAIS
     # @param client_secret [String] the client secret to authenticate with MAIS
     # @param base_url [String] the base URL for the API
-    def configure(client_id:, client_secret:, base_url:)
+    # @param token_url [String] the base token URL for authentication (getting token)
+    def configure(client_id:, client_secret:, base_url:, token_url:)
       # rubocop:disable Style/OpenStructUse
       instance.config = OpenStruct.new(
-        token: Authenticator.token(client_id, client_secret, base_url),
+        token: Authenticator.token(client_id, client_secret, token_url),
         client_id:,
         client_secret:,
         base_url:
@@ -117,7 +119,7 @@ class MaisOrcidClient
   # rubocop:disable Metrics/MethodLength
   def get_response(path, allow404: false)
     TokenWrapper.refresh(config) do
-      response = conn.get("/mais/orcid/v1#{path}")
+      response = conn.get("/orcid/v1#{path}")
 
       return if allow404 && response.status == 404
 

--- a/lib/mais_orcid_client/authenticator.rb
+++ b/lib/mais_orcid_client/authenticator.rb
@@ -18,8 +18,8 @@ class MaisOrcidClient
     # @return [String]
     def token
       client = OAuth2::Client.new(client_id, client_secret, site: base_url,
-                                                            token_url: '/api/oauth/token',
-                                                            authorize_url: '/api/oauth/authorize',
+                                                            token_url: '/oauth2/token',
+                                                            authorize_url: '/oauth2/authorize',
                                                             auth_scheme: :request_body)
       client.client_credentials.get_token.token
     end

--- a/lib/mais_orcid_client/token_wrapper.rb
+++ b/lib/mais_orcid_client/token_wrapper.rb
@@ -6,7 +6,7 @@ class MaisOrcidClient
     def self.refresh(config)
       yield
     rescue UnexpectedResponse::UnauthorizedError
-      config.token = Authenticator.token(config.client_id, config.client_secret, config.base_url)
+      config.token = Authenticator.token(config.client_id, config.client_secret, config.token_url)
       yield
     end
   end

--- a/lib/mais_orcid_client/version.rb
+++ b/lib/mais_orcid_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class MaisOrcidClient
-  VERSION = '0.4.0'
+  VERSION = '1.0.0'
 end

--- a/mais_orcid_client.gemspec
+++ b/mais_orcid_client.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday-retry'
   spec.add_dependency 'oauth2'
+  spec.add_dependency 'ostruct'
   spec.add_dependency 'zeitwerk'
 
   spec.add_development_dependency 'byebug'

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/raises.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/raises.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
+    uri: https://mais-uat.auth.us-west-2.amazoncognito.com/oauth2/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
     headers:
       User-Agent:
-      - Faraday v1.4.1
+      - Faraday v2.12.2
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,79 +21,74 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 24 May 2021 15:50:14 GMT
-      Server:
-      - ''
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-36cbab6022061daf8f35c868 0
-      Accept:
-      - "*/*"
-      Host:
-      - mais.suapiuat.stanford.edu
-      User-Agent:
-      - Faraday v1.4.1
-      Cache-Control:
-      - no-store
+      - Thu, 27 Mar 2025 20:20:36 GMT
       Content-Type:
-      - application/json
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - XSRF-TOKEN=b24e503b-46a0-467e-ac17-255653e62599; Path=/; Secure; HttpOnly;
+        SameSite=Lax
+      X-Amz-Cognito-Request-Id:
+      - be3ccfd4-011d-4a31-be28-1f6394ccacde
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
       Pragma:
       - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - DENY
+      Server:
+      - Server
     body:
       encoding: UTF-8
-      string: '{"access_token":"private_access_token","token_type":"Bearer","expires_in":3600,"scope":"orcid"}'
-  recorded_at: Mon, 24 May 2021 15:50:14 GMT
+      string: '{"access_token":"private_access_token","expires_in":3600,"token_type":"Bearer"}'
+  recorded_at: Thu, 27 Mar 2025 20:20:36 GMT
 - request:
     method: get
-    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users/totally-bogus
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users/totally-bogus
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
       - stanford-library-sul-pub
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Mon, 24 May 2021 15:50:14 GMT
       Authorization:
       - Bearer private_bearer_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 404
       message: Not Found
     headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Max-Forwards:
-      - '20'
-      Via:
-      - 1.0 ofapapiuat02.stanford.edu ()
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-36cbab600c06eb0e27cc7aab 0
       Date:
-      - Mon, 24 May 2021 15:50:14 GMT
-      Status:
-      - '404'
-      X-Sl-Assetpath:
-      - "/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Asseturipath:
-      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Authorized:
-      - 'true'
-      X-Sl-Clientip:
-      - 172.20.21.210
-      X-Sl-Pathinfo:
-      - totally-bogus
+      - Thu, 27 Mar 2025 20:20:36 GMT
       Content-Type:
       - application/json
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 699fffb2-38d4-45ed-99ad-3e864dcfef6f
+      X-Amz-Apigw-Id:
+      - IGjrREBOPHcEYyw=
+      X-Amzn-Trace-Id:
+      - Root=1-67e5b314-223d86317be91413442e845d
     body:
       encoding: UTF-8
-      string: '{"status":404,"errorMessage":"SUNet Id ''totally-bogus does not exist."}'
-  recorded_at: Mon, 24 May 2021 15:50:14 GMT
-recorded_with: VCR 6.0.0
+      string: '{"status":404,"errorMessage":"ORCID Id ''totally-bogus'' does not exist."}'
+  recorded_at: Thu, 27 Mar 2025 20:20:36 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/raises.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/raises.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://aswsuat.stanford.edu/api/oauth/token
+    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
@@ -31,7 +31,7 @@ http_interactions:
       Accept:
       - "*/*"
       Host:
-      - aswsuat.stanford.edu
+      - mais.suapiuat.stanford.edu
       User-Agent:
       - Faraday v1.4.1
       Cache-Control:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Mon, 24 May 2021 15:50:14 GMT
 - request:
     method: get
-    uri: https://aswsuat.stanford.edu/mais/orcid/v1/users/totally-bogus
+    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users/totally-bogus
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/raises_by_orcidid.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/raises_by_orcidid.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
+    uri: https://mais-uat.auth.us-west-2.amazoncognito.com/oauth2/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
     headers:
       User-Agent:
-      - Faraday v2.7.10
+      - Faraday v2.12.2
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,32 +21,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 19 Jul 2023 16:46:32 GMT
-      Server:
-      - ''
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-6813b8641b13fdbb573cf0b3 0
-      Accept:
-      - "*/*"
-      Host:
-      - mais.suapiuat.stanford.edu
-      User-Agent:
-      - Faraday v2.7.10
-      Cache-Control:
-      - no-store
+      - Thu, 27 Mar 2025 20:21:10 GMT
       Content-Type:
-      - application/json
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - XSRF-TOKEN=5a051ff4-cb00-48ba-aa8f-4d8198ce8bde; Path=/; Secure; HttpOnly;
+        SameSite=Lax
+      X-Amz-Cognito-Request-Id:
+      - 4ad44864-83a5-48ab-aaa8-c57eadb8171c
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
       Pragma:
       - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - DENY
+      Server:
+      - Server
     body:
       encoding: UTF-8
-      string: '{"access_token":"private_access_token","token_type":"Bearer","expires_in":3600,"scope":"orcid"}'
-  recorded_at: Wed, 19 Jul 2023 16:46:31 GMT
+      string: '{"access_token":"private_access_token","expires_in":3600,"token_type":"Bearer"}'
+  recorded_at: Thu, 27 Mar 2025 20:21:10 GMT
 - request:
     method: get
-    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users/0000-0002-5466-7798
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users/0000-0002-5466-7798
     body:
       encoding: US-ASCII
       string: ''
@@ -64,49 +73,23 @@ http_interactions:
       code: 404
       message: Not Found
     headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Max-Forwards:
-      - '20'
-      Via:
-      - 1.0 ofapapiuat02.stanford.edu ()
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-6813b8641c132c3e5a4dfb5d 0
       Date:
-      - Wed, 19 Jul 2023 16:46:32 GMT
-      Referrer-Policy:
-      - strict-origin
-      Status:
-      - '404'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains;
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Sl-Assetpath:
-      - "/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Asseturipath:
-      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Authorized:
-      - 'true'
-      X-Sl-Clientip:
-      - 172.20.21.210
-      X-Sl-Pathinfo:
-      - 0000-0002-5466-7798
-      X-Sl-Proxy:
-      - 'false'
-      X-Xss-Protection:
-      - 1; mode=block
-      Content-Security-Policy:
-      - default-src 'self'; font-src *;img-src * data:; script-src *; style-src *;
+      - Thu, 27 Mar 2025 20:21:10 GMT
       Content-Type:
       - application/json
+      Content-Length:
+      - '78'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 0e408faf-055b-438d-8ad7-3c1934bca5e5
+      X-Amz-Apigw-Id:
+      - IGjwjEJbvHcEJSA=
+      X-Amzn-Trace-Id:
+      - Root=1-67e5b336-7828506e368d3f2819713101
     body:
       encoding: UTF-8
       string: '{"status":404,"errorMessage":"ORCID Id ''0000-0002-5466-7798'' does
         not exist."}'
-  recorded_at: Wed, 19 Jul 2023 16:46:32 GMT
-recorded_with: VCR 6.2.0
+  recorded_at: Thu, 27 Mar 2025 20:21:10 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/raises_by_orcidid.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/raises_by_orcidid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://aswsuat.stanford.edu/api/oauth/token
+    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
@@ -31,7 +31,7 @@ http_interactions:
       Accept:
       - "*/*"
       Host:
-      - aswsuat.stanford.edu
+      - mais.suapiuat.stanford.edu
       User-Agent:
       - Faraday v2.7.10
       Cache-Control:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 19 Jul 2023 16:46:31 GMT
 - request:
     method: get
-    uri: https://aswsuat.stanford.edu/mais/orcid/v1/users/0000-0002-5466-7798
+    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users/0000-0002-5466-7798
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/retreives_user_by_orcidid.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/retreives_user_by_orcidid.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
+    uri: https://mais-uat.auth.us-west-2.amazoncognito.com/oauth2/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
     headers:
       User-Agent:
-      - Faraday v2.7.10
+      - Faraday v2.12.2
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,32 +21,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 18 Jul 2023 21:39:58 GMT
-      Server:
-      - ''
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-ae06b7643b1c50f941fbc694 0
-      Accept:
-      - "*/*"
-      Host:
-      - mais.suapiuat.stanford.edu
-      User-Agent:
-      - Faraday v2.7.10
-      Cache-Control:
-      - no-store
+      - Thu, 27 Mar 2025 20:21:09 GMT
       Content-Type:
-      - application/json
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - XSRF-TOKEN=4534b001-91af-4b4a-8645-9364b5df99b6; Path=/; Secure; HttpOnly;
+        SameSite=Lax
+      X-Amz-Cognito-Request-Id:
+      - e155840d-0a50-42f5-9f3c-b13e28960b71
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
       Pragma:
       - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - DENY
+      Server:
+      - Server
     body:
       encoding: UTF-8
-      string: '{"access_token":"private_access_token","token_type":"Bearer","expires_in":3600,"scope":"orcid"}'
-  recorded_at: Tue, 18 Jul 2023 21:39:58 GMT
+      string: '{"access_token":"private_access_token","expires_in":3600,"token_type":"Bearer"}'
+  recorded_at: Thu, 27 Mar 2025 20:21:09 GMT
 - request:
     method: get
-    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users/0000-0002-5466-7797
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users/0000-0002-5466-7797
     body:
       encoding: US-ASCII
       string: ''
@@ -64,48 +73,22 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Max-Forwards:
-      - '20'
-      Via:
-      - 1.0 ofapapiuat01.stanford.edu ()
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-ae06b7643c1cc85b6dc91c72 0
       Date:
-      - Tue, 18 Jul 2023 21:39:58 GMT
-      Referrer-Policy:
-      - strict-origin
-      Status:
-      - '200'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains;
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Sl-Assetpath:
-      - "/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Asseturipath:
-      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Authorized:
-      - 'true'
-      X-Sl-Clientip:
-      - 172.20.21.210
-      X-Sl-Pathinfo:
-      - 0000-0002-5466-7797
-      X-Sl-Proxy:
-      - 'false'
-      X-Xss-Protection:
-      - 1; mode=block
-      Content-Security-Policy:
-      - default-src 'self'; font-src *;img-src * data:; script-src *; style-src *;
+      - Thu, 27 Mar 2025 20:21:10 GMT
       Content-Type:
       - application/json
+      Content-Length:
+      - '241'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 80bc25b8-b150-4827-8e46-6a760a4c4f1f
+      X-Amz-Apigw-Id:
+      - IGjweGfpvHcEE3w=
+      X-Amzn-Trace-Id:
+      - Root=1-67e5b335-6a438495365817fe76233499
     body:
       encoding: UTF-8
-      string: '{"sunet_id":"vivnwong","orcid_id":"https://sandbox.orcid.org/0000-0002-5466-7797","access_token":"XXXXXXXX-7e60-4f7b-b7d4-4bd21d9c5618","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T09:50:14.000"}'
-  recorded_at: Tue, 18 Jul 2023 21:39:58 GMT
-recorded_with: VCR 6.2.0
+      string: '{"sunet_id":"vivnwong","orcid_id":"https://sandbox.orcid.org/0000-0002-5466-7797","access_token":"private_access_token","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T09:50:14.000"}'
+  recorded_at: Thu, 27 Mar 2025 20:21:10 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/retreives_user_by_orcidid.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/retreives_user_by_orcidid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://aswsuat.stanford.edu/api/oauth/token
+    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
@@ -31,7 +31,7 @@ http_interactions:
       Accept:
       - "*/*"
       Host:
-      - aswsuat.stanford.edu
+      - mais.suapiuat.stanford.edu
       User-Agent:
       - Faraday v2.7.10
       Cache-Control:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Tue, 18 Jul 2023 21:39:58 GMT
 - request:
     method: get
-    uri: https://aswsuat.stanford.edu/mais/orcid/v1/users/0000-0002-5466-7797
+    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users/0000-0002-5466-7797
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/retrieves_user.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/retrieves_user.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
+    uri: https://mais-uat.auth.us-west-2.amazoncognito.com/oauth2/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
     headers:
       User-Agent:
-      - Faraday v1.4.1
+      - Faraday v2.12.2
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,79 +21,74 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 24 May 2021 15:50:13 GMT
-      Server:
-      - ''
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-35cbab60210674c1c53bd811 0
-      Accept:
-      - "*/*"
-      Host:
-      - mais.suapiuat.stanford.edu
-      User-Agent:
-      - Faraday v1.4.1
-      Cache-Control:
-      - no-store
+      - Thu, 27 Mar 2025 20:21:09 GMT
       Content-Type:
-      - application/json
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - XSRF-TOKEN=1e1bbb7e-170c-4cf9-b60b-a273cde72f00; Path=/; Secure; HttpOnly;
+        SameSite=Lax
+      X-Amz-Cognito-Request-Id:
+      - 61f2cc84-2fd7-4f73-a0a0-6b27a3bc62ce
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
       Pragma:
       - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - DENY
+      Server:
+      - Server
     body:
       encoding: UTF-8
-      string: '{"access_token":"private_access_token","token_type":"Bearer","expires_in":3600,"scope":"orcid"}'
-  recorded_at: Mon, 24 May 2021 15:50:13 GMT
+      string: '{"access_token":"private_access_token","expires_in":3600,"token_type":"Bearer"}'
+  recorded_at: Thu, 27 Mar 2025 20:21:09 GMT
 - request:
     method: get
-    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users/nataliex
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users/tdelcont
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
       - stanford-library-sul-pub
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Mon, 24 May 2021 15:50:13 GMT
       Authorization:
       - Bearer private_bearer_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Max-Forwards:
-      - '20'
-      Via:
-      - 1.0 ofapapiuat02.stanford.edu ()
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-35cbab600b06d6a41155d6d9 0
       Date:
-      - Mon, 24 May 2021 15:50:13 GMT
-      Status:
-      - '200'
-      X-Sl-Assetpath:
-      - "/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Asseturipath:
-      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Authorized:
-      - 'true'
-      X-Sl-Clientip:
-      - 172.20.21.210
-      X-Sl-Pathinfo:
-      - nataliex
+      - Thu, 27 Mar 2025 20:21:09 GMT
       Content-Type:
       - application/json
+      Content-Length:
+      - '203'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - a5c7d8c6-5aa8-4e13-ab23-504c9bbbac02
+      X-Amz-Apigw-Id:
+      - IGjwYEbtvHcET5g=
+      X-Amzn-Trace-Id:
+      - Root=1-67e5b335-574332ee6976ff227dc0abcd
     body:
       encoding: UTF-8
-      string: '{"sunet_id":"nataliex","orcid_id":"https://sandbox.orcid.org/0000-0001-7161-1827","access_token":"XXXXXXXX-1ac5-4ea7-835d-bc6d61ffb9a8","scope":["/read-limited"],"last_updated":"2020-01-23T17:06:21.000"}'
-  recorded_at: Mon, 24 May 2021 15:50:14 GMT
-recorded_with: VCR 6.0.0
+      string: '{"sunet_id":"tdelcont","orcid_id":"https://sandbox.orcid.org/0000-0002-4589-7232","access_token":"private_access_token","scope":["/read-limited"],"last_updated":"2021-05-07T22:11:00.000"}'
+  recorded_at: Thu, 27 Mar 2025 20:21:09 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/retrieves_user.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_user/retrieves_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://aswsuat.stanford.edu/api/oauth/token
+    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
@@ -31,7 +31,7 @@ http_interactions:
       Accept:
       - "*/*"
       Host:
-      - aswsuat.stanford.edu
+      - mais.suapiuat.stanford.edu
       User-Agent:
       - Faraday v1.4.1
       Cache-Control:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Mon, 24 May 2021 15:50:13 GMT
 - request:
     method: get
-    uri: https://aswsuat.stanford.edu/mais/orcid/v1/users/nataliex
+    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users/nataliex
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/raises.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/raises.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://aswsuat.stanford.edu/api/oauth/token
+    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
     body:
       encoding: UTF-8
       string: client_id=5g123456-6cbf-4272-91eb-659948ce441a&client_secret=12ad9c34-80dr-46h9-b7eb-6543108a0c71&grant_type=client_credentials
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Tue, 11 May 2021 22:33:00 GMT
 - request:
     method: get
-    uri: https://aswsuat.stanford.edu/mais/orcid/v1/users?page_size=2&scope=ANY
+    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users?page_size=2&scope=ANY
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/raises.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/raises.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
+    uri: https://mais-uat.auth.us-west-2.amazoncognito.com/oauth2/token
     body:
       encoding: UTF-8
-      string: client_id=5g123456-6cbf-4272-91eb-659948ce441a&client_secret=12ad9c34-80dr-46h9-b7eb-6543108a0c71&grant_type=client_credentials
+      string: client_id=abc123&client_secret=def456&grant_type=client_credentials
     headers:
       User-Agent:
-      - Faraday v1.4.1
+      - Faraday v2.12.2
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,73 +21,74 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 11 May 2021 22:33:00 GMT
-      Server:
-      - ''
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-1c069b60e22742b7a7cfc7ce 0
-      Accept:
-      - "*/*"
-      Host:
-      - aswstest.stanford.edu
-      User-Agent:
-      - Faraday v1.4.1
-      Cache-Control:
-      - no-store
+      - Thu, 27 Mar 2025 20:04:01 GMT
       Content-Type:
-      - application/json
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - XSRF-TOKEN=e1988e73-16ec-448f-8843-29418fb6172d; Path=/; Secure; HttpOnly;
+        SameSite=Lax
+      X-Amz-Cognito-Request-Id:
+      - 7184fc2c-c8b9-417c-a7d5-56f8b4ed46d9
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
       Pragma:
       - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - DENY
+      Server:
+      - Server
     body:
       encoding: UTF-8
-      string: '{"access_token":"private_access_token","token_type":"Bearer","expires_in":3600,"scope":"orcid"}'
-  recorded_at: Tue, 11 May 2021 22:33:00 GMT
+      string: '{"access_token":"private_access_token","expires_in":3600,"token_type":"Bearer"}'
+  recorded_at: Thu, 27 Mar 2025 20:04:01 GMT
 - request:
     method: get
-    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users?page_size=2&scope=ANY
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users?page_size=2&scope=ANY
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
       - stanford-library-sul-pub
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Tue, 11 May 2021 22:33:00 GMT
       Authorization:
       - Bearer private_bearer_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 500
-      message: Internal Server Error
+      message: OK
     headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Server:
-      - ''
-      Content-Length:
-      - '0'
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-1c069b60c827515dde98b1b3 0
-      Accept:
-      - "*/*"
-      Authorization:
-      - Bearer private_bearer_token
       Date:
-      - Tue, 11 May 2021 22:33:00 GMT
-      Host:
-      - aswstest.stanford.edu
-      User-Agent:
-      - stanford-library-sul-pub
+      - Thu, 27 Mar 2025 20:04:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3139'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - c9ffdc20-6c74-4e1e-aea9-970244b6cb4a
+      X-Amz-Apigw-Id:
+      - IGhP1Hx3vHcEumA=
+      X-Amzn-Trace-Id:
+      - Root=1-67e5af31-1f46afb15467a4cd4cfac721
     body:
       encoding: UTF-8
-      string: ''
-  recorded_at: Tue, 11 May 2021 22:33:00 GMT
-recorded_with: VCR 6.0.0
+      string: '{"status":500,"errorMessage":"Boom! Something went wrong on the server."}'
+  recorded_at: Thu, 27 Mar 2025 20:04:02 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/retrieves_users.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/retrieves_users.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
+    uri: https://mais-uat.auth.us-west-2.amazoncognito.com/oauth2/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
     headers:
       User-Agent:
-      - Faraday v1.4.1
+      - Faraday v2.12.2
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,183 +21,74 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 24 May 2021 15:50:12 GMT
-      Server:
-      - ''
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-34cbab601d069591910c5109 0
-      Accept:
-      - "*/*"
-      Host:
-      - mais.suapiuat.stanford.edu
-      User-Agent:
-      - Faraday v1.4.1
-      Cache-Control:
-      - no-store
+      - Thu, 27 Mar 2025 20:21:08 GMT
       Content-Type:
-      - application/json
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - XSRF-TOKEN=73b0b14d-6c2d-4acf-8a66-a43a503b5f1a; Path=/; Secure; HttpOnly;
+        SameSite=Lax
+      X-Amz-Cognito-Request-Id:
+      - 38a61c28-8840-4b58-b67a-a17eec6e7bba
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
       Pragma:
       - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - DENY
+      Server:
+      - Server
     body:
       encoding: UTF-8
-      string: '{"access_token":"private_access_token","token_type":"Bearer","expires_in":3599,"scope":"orcid"}'
-  recorded_at: Mon, 24 May 2021 15:50:12 GMT
+      string: '{"access_token":"private_access_token","expires_in":3600,"token_type":"Bearer"}'
+  recorded_at: Thu, 27 Mar 2025 20:21:08 GMT
 - request:
     method: get
-    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users?page_size=2&scope=ANY
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users?page_size=2&scope=ANY
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
       - stanford-library-sul-pub
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Mon, 24 May 2021 15:50:12 GMT
       Authorization:
       - Bearer private_bearer_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Max-Forwards:
-      - '20'
-      Via:
-      - 1.0 ofapapiuat02.stanford.edu ()
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-34cbab60070657b197b80bb8 0
       Date:
-      - Mon, 24 May 2021 15:50:12 GMT
-      Status:
-      - '200'
-      X-Sl-Assetpath:
-      - "/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Asseturipath:
-      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Authorized:
-      - 'true'
-      X-Sl-Clientip:
-      - 172.20.21.210
-      X-Sl-Pathinfo:
-      - ''
+      - Thu, 27 Mar 2025 20:21:09 GMT
       Content-Type:
       - application/json
-    body:
-      encoding: UTF-8
-      string: '{"meta":{"current_page":1,"total_records":146,"page_size":2,"total_pages":73},"results":[{"sunet_id":"nataliex","orcid_id":"https://sandbox.orcid.org/0000-0001-7161-1827","access_token":"XXXXXXXX-1ac5-4ea7-835d-bc6d61ffb9a8","scope":["/read-limited"],"last_updated":"2020-01-23T17:06:21.000"},{"sunet_id":"zechandl","orcid_id":"https://sandbox.orcid.org/0000-0003-2402-9839","access_token":"XXXXXXXX-222b-4123-9900-9b8da6392d3b","scope":["/read-limited"],"last_updated":"2020-01-23T17:13:58.000"}],"links":{"self":"/users?scope=any&page_number=1&page_size=2","first":"/users?scope=any&page_number=1&page_size=2","prev":"","next":"/users?scope=any&page_number=2&page_size=2","last":"/users?scope=any&page_number=73&page_size=2"}}'
-  recorded_at: Mon, 24 May 2021 15:50:13 GMT
-- request:
-    method: get
-    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users?page_number=2&page_size=2&scope=any
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - stanford-library-sul-pub
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Mon, 24 May 2021 15:50:13 GMT
-      Authorization:
-      - Bearer private_bearer_token
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Max-Forwards:
-      - '20'
-      Via:
-      - 1.0 ofapapiuat01.stanford.edu ()
+      Content-Length:
+      - '3139'
       Connection:
-      - close
-      X-Correlationid:
-      - Id-35cbab601e060c02868ca641 0
-      Date:
-      - Mon, 24 May 2021 15:50:13 GMT
-      Status:
-      - '200'
-      X-Sl-Assetpath:
-      - "/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Asseturipath:
-      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Authorized:
-      - 'true'
-      X-Sl-Clientip:
-      - 172.20.21.210
-      X-Sl-Pathinfo:
-      - ''
-      Content-Type:
-      - application/json
+      - keep-alive
+      X-Amzn-Requestid:
+      - 130d2d40-f18d-424b-bc21-8cff058cb05b
+      X-Amz-Apigw-Id:
+      - IGjwTGqjvHcEtKw=
+      X-Amzn-Trace-Id:
+      - Root=1-67e5b334-07edc35a2e7541fa07742ff3
     body:
       encoding: UTF-8
-      string: '{"meta":{"current_page":2,"total_records":146,"page_size":2,"total_pages":73},"results":[{"sunet_id":"aconner","orcid_id":"https://sandbox.orcid.org/0000-0003-1523-913X","access_token":"XXXXXXXX-d714-4fdc-8a73-5b22b689bb00","scope":["/read-limited"],"last_updated":"2020-01-23T19:03:33.000"},{"sunet_id":"jborghi","orcid_id":"https://sandbox.orcid.org/0000-0001-9570-4163","access_token":"XXXXXXXX-8a69-415e-8cd5-69115df98ea1","scope":["/read-limited"],"last_updated":"2020-01-23T19:33:48.000"}],"links":{"self":"/users?scope=any&page_number=2&page_size=2","first":"/users?scope=any&page_number=1&page_size=2","prev":"/users?scope=any&page_number=1&page_size=2","next":"/users?scope=any&page_number=3&page_size=2","last":"/users?scope=any&page_number=73&page_size=2"}}'
-  recorded_at: Mon, 24 May 2021 15:50:13 GMT
-- request:
-    method: get
-    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users?page_number=3&page_size=2&scope=any
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - stanford-library-sul-pub
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Mon, 24 May 2021 15:50:13 GMT
-      Authorization:
-      - Bearer private_bearer_token
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Allow:
-      - GET, HEAD, OPTIONS
-      Max-Forwards:
-      - '20'
-      Via:
-      - 1.0 ofapapiuat02.stanford.edu ()
-      Connection:
-      - close
-      X-Correlationid:
-      - Id-35cbab60080667c58e8ef370 0
-      Date:
-      - Mon, 24 May 2021 15:50:13 GMT
-      Status:
-      - '200'
-      X-Sl-Assetpath:
-      - "/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Asseturipath:
-      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
-      X-Sl-Authorized:
-      - 'true'
-      X-Sl-Clientip:
-      - 172.20.21.210
-      X-Sl-Pathinfo:
-      - ''
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"meta":{"current_page":3,"total_records":146,"page_size":2,"total_pages":73},"results":[{"sunet_id":"ccuddy","orcid_id":"https://sandbox.orcid.org/0000-0003-2460-7096","access_token":"XXXXXXXX-8363-4523-bd27-7c2028abf3c9","scope":["/read-limited"],"last_updated":"2020-01-24T15:04:58.000"},{"sunet_id":"graceb","orcid_id":"https://sandbox.orcid.org/0000-0003-2570-9123","access_token":"XXXXXXXX-bd36-4ea3-9fe2-a762431e3b38","scope":["/read-limited"],"last_updated":"2020-01-24T15:38:02.000"}],"links":{"self":"/users?scope=any&page_number=3&page_size=2","first":"/users?scope=any&page_number=1&page_size=2","prev":"/users?scope=any&page_number=2&page_size=2","next":"/users?scope=any&page_number=4&page_size=2","last":"/users?scope=any&page_number=73&page_size=2"}}'
-  recorded_at: Mon, 24 May 2021 15:50:13 GMT
-recorded_with: VCR 6.0.0
+      string: '{"meta":{"current_page":1,"total_records":12,"page_size":100,"total_pages":1},"results":[{"sunet_id":"tdelcont","orcid_id":"https://sandbox.orcid.org/0000-0002-4589-7232","access_token":"private_access_token","scope":["/read-limited"],"last_updated":"2021-05-07T22:11:00.000"},{"sunet_id":"jlittman","orcid_id":"https://sandbox.orcid.org/0000-0003-3437-349X","access_token":"68cf29cb-294e-4bc8-8afd-96315b06ae04","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T05:04:24.000"},{"sunet_id":"ddieckma","orcid_id":"https://sandbox.orcid.org/0000-0002-4481-5100","access_token":"f4ff7836-e1b0-4885-83f5-1909e355d017","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T09:27:54.000"},{"sunet_id":"muet","orcid_id":"https://sandbox.orcid.org/0000-0001-5226-468X","access_token":"ece59039-d70d-4ca0-ab46-f4b77801770d","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T09:46:44.000"},{"sunet_id":"amyhodge","orcid_id":"https://sandbox.orcid.org/0000-0002-4933-2837","access_token":"e7332b15-4efd-45be-a079-cfbb60397781","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-27T14:46:58.000"},{"sunet_id":"jtim","orcid_id":"https://sandbox.orcid.org/0000-0002-7262-6251","access_token":"88674490-60db-442d-90f7-c676bb1f2727","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T08:15:07.000"},{"sunet_id":"vivnwong","orcid_id":"https://sandbox.orcid.org/0000-0002-5466-7797","access_token":"709b6b08-7e60-4f7b-b7d4-4bd21d9c5618","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T09:50:14.000"},{"sunet_id":"ndushay","orcid_id":"https://sandbox.orcid.org/0000-0003-0962-2466","access_token":"191a80ba-78a8-4316-b8a9-ff3e37794597","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-06-01T10:21:10.000"},{"sunet_id":"kcasciot","orcid_id":"https://sandbox.orcid.org/0000-0002-7372-3555","access_token":"18e3b4d7-5afa-44ed-a8ba-1dce23cd9472","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-06-04T10:07:52.000"},{"sunet_id":"petucket","orcid_id":"https://sandbox.orcid.org/0000-0002-2230-4756","access_token":"22eb1288-2a84-4878-bcdb-f3ab7a4e8db2","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-10-13T11:37:46.000"},{"sunet_id":"etlouie","orcid_id":"https://sandbox.orcid.org/0000-0003-0525-7799","access_token":"5641416d-3af8-4ee9-b800-5e65ded97284","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2022-01-14T18:25:01.000"},{"sunet_id":"narmadha","orcid_id":"https://sandbox.orcid.org/0000-0001-7133-5674","access_token":"e8b02595-8672-42d9-8545-e1d92f9c1bf1","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2022-02-22T18:04:44.000"}],"links":{"self":"/users?scope=any&page_number=1&page_size=100","first":"/users?scope=any&page_number=1&page_size=100","prev":"","next":"","last":"/users?scope=any&page_number=1&page_size=100"}}'
+  recorded_at: Thu, 27 Mar 2025 20:21:08 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/retrieves_users.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/retrieves_users.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://aswsuat.stanford.edu/api/oauth/token
+    uri: https://mais.suapiuat.stanford.edu/api/oauth/token
     body:
       encoding: UTF-8
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
@@ -31,7 +31,7 @@ http_interactions:
       Accept:
       - "*/*"
       Host:
-      - aswsuat.stanford.edu
+      - mais.suapiuat.stanford.edu
       User-Agent:
       - Faraday v1.4.1
       Cache-Control:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Mon, 24 May 2021 15:50:12 GMT
 - request:
     method: get
-    uri: https://aswsuat.stanford.edu/mais/orcid/v1/users?page_size=2&scope=ANY
+    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users?page_size=2&scope=ANY
     body:
       encoding: UTF-8
       string: ''
@@ -98,7 +98,7 @@ http_interactions:
   recorded_at: Mon, 24 May 2021 15:50:13 GMT
 - request:
     method: get
-    uri: https://aswsuat.stanford.edu/mais/orcid/v1/users?page_number=2&page_size=2&scope=any
+    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users?page_number=2&page_size=2&scope=any
     body:
       encoding: UTF-8
       string: ''
@@ -150,7 +150,7 @@ http_interactions:
   recorded_at: Mon, 24 May 2021 15:50:13 GMT
 - request:
     method: get
-    uri: https://aswsuat.stanford.edu/mais/orcid/v1/users?page_number=3&page_size=2&scope=any
+    uri: https://mais.suapiuat.stanford.edu/mais/orcid/v1/users?page_number=3&page_size=2&scope=any
     body:
       encoding: UTF-8
       string: ''

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_set_user_agent.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_set_user_agent.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://mais-uat.auth.us-west-2.amazoncognito.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: client_id=abc123&client_secret=def456&grant_type=client_credentials
+    headers:
+      User-Agent:
+      - Faraday v2.12.2
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Mar 2025 17:59:29 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - XSRF-TOKEN=1709d90d-0fcc-4571-a643-96d4d968d647; Path=/; Secure; HttpOnly;
+        SameSite=Lax
+      X-Amz-Cognito-Request-Id:
+      - d97c8391-663e-4a1d-8d15-90cfca9bbdf1
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - DENY
+      Server:
+      - Server
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"private_access_token","expires_in":3600,"token_type":"Bearer"}'
+  recorded_at: Fri, 28 Mar 2025 17:59:29 GMT
+- request:
+    method: get
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users?scope=ANY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - custom-user-agent
+      Authorization:
+      - Bearer private_bearer_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Mar 2025 17:59:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3139'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 3e11d3ab-d6a0-4a03-b686-904a0ab063c0
+      X-Amz-Apigw-Id:
+      - IJh8RHbEvHcEf3A=
+      X-Amzn-Trace-Id:
+      - Root=1-67e6e381-36296fa5387aafd66f21fa5d
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"current_page":1,"total_records":12,"page_size":100,"total_pages":1},"results":[{"sunet_id":"tdelcont","orcid_id":"https://sandbox.orcid.org/0000-0002-4589-7232","access_token":"private_access_token","scope":["/read-limited"],"last_updated":"2021-05-07T22:11:00.000"},{"sunet_id":"jlittman","orcid_id":"https://sandbox.orcid.org/0000-0003-3437-349X","access_token":"68cf29cb-294e-4bc8-8afd-96315b06ae04","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T05:04:24.000"},{"sunet_id":"ddieckma","orcid_id":"https://sandbox.orcid.org/0000-0002-4481-5100","access_token":"f4ff7836-e1b0-4885-83f5-1909e355d017","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T09:27:54.000"},{"sunet_id":"muet","orcid_id":"https://sandbox.orcid.org/0000-0001-5226-468X","access_token":"ece59039-d70d-4ca0-ab46-f4b77801770d","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T09:46:44.000"},{"sunet_id":"amyhodge","orcid_id":"https://sandbox.orcid.org/0000-0002-4933-2837","access_token":"e7332b15-4efd-45be-a079-cfbb60397781","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-27T14:46:58.000"},{"sunet_id":"jtim","orcid_id":"https://sandbox.orcid.org/0000-0002-7262-6251","access_token":"88674490-60db-442d-90f7-c676bb1f2727","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T08:15:07.000"},{"sunet_id":"vivnwong","orcid_id":"https://sandbox.orcid.org/0000-0002-5466-7797","access_token":"709b6b08-7e60-4f7b-b7d4-4bd21d9c5618","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T09:50:14.000"},{"sunet_id":"ndushay","orcid_id":"https://sandbox.orcid.org/0000-0003-0962-2466","access_token":"191a80ba-78a8-4316-b8a9-ff3e37794597","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-06-01T10:21:10.000"},{"sunet_id":"kcasciot","orcid_id":"https://sandbox.orcid.org/0000-0002-7372-3555","access_token":"18e3b4d7-5afa-44ed-a8ba-1dce23cd9472","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-06-04T10:07:52.000"},{"sunet_id":"petucket","orcid_id":"https://sandbox.orcid.org/0000-0002-2230-4756","access_token":"22eb1288-2a84-4878-bcdb-f3ab7a4e8db2","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-10-13T11:37:46.000"},{"sunet_id":"etlouie","orcid_id":"https://sandbox.orcid.org/0000-0003-0525-7799","access_token":"5641416d-3af8-4ee9-b800-5e65ded97284","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2022-01-14T18:25:01.000"},{"sunet_id":"narmadha","orcid_id":"https://sandbox.orcid.org/0000-0001-7133-5674","access_token":"e8b02595-8672-42d9-8545-e1d92f9c1bf1","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2022-02-22T18:04:44.000"}],"links":{"self":"/users?scope=any&page_number=1&page_size=100","first":"/users?scope=any&page_number=1&page_size=100","prev":"","next":"","last":"/users?scope=any&page_number=1&page_size=100"}}'
+  recorded_at: Fri, 28 Mar 2025 17:59:29 GMT
+recorded_with: VCR 6.3.1

--- a/spec/mais_orcid_client_spec.rb
+++ b/spec/mais_orcid_client_spec.rb
@@ -113,4 +113,24 @@ RSpec.describe MaisOrcidClient do
       end
     end
   end
+
+  describe 'sets user agent' do
+    let(:client) do
+      described_class.configure(
+        client_id: FAKE_CLIENT_ID,
+        client_secret: FAKE_CLIENT_SECRET,
+        base_url: 'https://mais.suapiuat.stanford.edu',
+        token_url: 'https://mais-uat.auth.us-west-2.amazoncognito.com',
+        user_agent: 'custom-user-agent'
+      )
+    end
+
+    it 'sets the user agent in the request headers' do
+      VCR.use_cassette('Mais_Client/_set_user_agent') do
+        client.fetch_orcid_users(limit: 1)
+        expect(WebMock).to have_requested(:get, 'https://mais.suapiuat.stanford.edu/orcid/v1/users?scope=ANY')
+          .with(headers: { 'User-Agent' => 'custom-user-agent' })
+      end
+    end
+  end
 end

--- a/spec/mais_orcid_client_spec.rb
+++ b/spec/mais_orcid_client_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MaisOrcidClient do
     described_class.configure(
       client_id: FAKE_CLIENT_ID,
       client_secret: FAKE_CLIENT_SECRET,
-      base_url: 'https://aswsuat.stanford.edu'
+      base_url: 'https://mais.suapiuat.stanford.edu'
     )
   end
 

--- a/spec/mais_orcid_client_spec.rb
+++ b/spec/mais_orcid_client_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe MaisOrcidClient do
     described_class.configure(
       client_id: FAKE_CLIENT_ID,
       client_secret: FAKE_CLIENT_SECRET,
-      base_url: 'https://mais.suapiuat.stanford.edu'
+      base_url: 'https://mais.suapiuat.stanford.edu',
+      token_url: 'https://mais-uat.auth.us-west-2.amazoncognito.com'
     )
   end
 
@@ -23,15 +24,15 @@ RSpec.describe MaisOrcidClient do
     it 'retrieves users' do
       VCR.use_cassette('Mais_Client/_fetch_orcid_users/retrieves users') do
         expect(orcid_users.size).to eq(5)
-        expect(orcid_users.first).to eq(MaisOrcidClient::OrcidUser.new('nataliex',
-                                                                       'https://sandbox.orcid.org/0000-0001-7161-1827',
+        expect(orcid_users.first).to eq(MaisOrcidClient::OrcidUser.new('tdelcont',
+                                                                       'https://sandbox.orcid.org/0000-0002-4589-7232',
                                                                        ['/read-limited'],
-                                                                       'XXXXXXXX-1ac5-4ea7-835d-bc6d61ffb9a8',
-                                                                       '2020-01-23T17:06:21.000'))
+                                                                       'private_access_token',
+                                                                       '2021-05-07T22:11:00.000'))
       end
     end
 
-    context 'when server returns 500' do
+    context 'when server returns 404' do
       it 'raises ServerError' do
         VCR.use_cassette('Mais_Client/_fetch_orcid_users/raises') do
           expect { orcid_users }.to raise_error(MaisOrcidClient::UnexpectedResponse::ServerError)
@@ -41,7 +42,7 @@ RSpec.describe MaisOrcidClient do
   end
 
   describe '#fetch_orcid_user' do
-    let(:orcid_user_by_sunetid) { subject.fetch_orcid_user(sunetid: 'nataliex') }
+    let(:orcid_user_by_sunetid) { subject.fetch_orcid_user(sunetid: 'tdelcont') }
     let(:bad_orcid_user_by_sunetid) { subject.fetch_orcid_user(sunetid: 'totally-bogus') }
     let(:orcid_user_by_orcidid) { subject.fetch_orcid_user(orcidid: 'https://sandbox.orcid.org/0000-0002-5466-7797') }
     let(:bare_orcid_user_by_orcidid) { subject.fetch_orcid_user(orcidid: '0000-0002-5466-7797') }
@@ -51,11 +52,11 @@ RSpec.describe MaisOrcidClient do
 
     it 'retrieves a single user by sunetid' do
       VCR.use_cassette('Mais_Client/_fetch_orcid_user/retrieves user') do
-        expect(orcid_user_by_sunetid).to eq(MaisOrcidClient::OrcidUser.new('nataliex',
-                                                                           'https://sandbox.orcid.org/0000-0001-7161-1827',
+        expect(orcid_user_by_sunetid).to eq(MaisOrcidClient::OrcidUser.new('tdelcont',
+                                                                           'https://sandbox.orcid.org/0000-0002-4589-7232',
                                                                            ['/read-limited'],
-                                                                           'XXXXXXXX-1ac5-4ea7-835d-bc6d61ffb9a8',
-                                                                           '2020-01-23T17:06:21.000'))
+                                                                           'private_access_token',
+                                                                           '2021-05-07T22:11:00.000'))
       end
     end
 
@@ -73,7 +74,7 @@ RSpec.describe MaisOrcidClient do
                                                                            'https://sandbox.orcid.org/0000-0002-5466-7797',
                                                                            ['/read-limited', '/activities/update',
                                                                             '/person/update'],
-                                                                           'XXXXXXXX-7e60-4f7b-b7d4-4bd21d9c5618',
+                                                                           'private_access_token',
                                                                            '2021-05-28T09:50:14.000'))
       end
     end
@@ -84,7 +85,7 @@ RSpec.describe MaisOrcidClient do
                                                                                 'https://sandbox.orcid.org/0000-0002-5466-7797',
                                                                                 ['/read-limited', '/activities/update',
                                                                                  '/person/update'],
-                                                                                'XXXXXXXX-7e60-4f7b-b7d4-4bd21d9c5618',
+                                                                                'private_access_token',
                                                                                 '2021-05-28T09:50:14.000'))
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,11 +45,11 @@ VCR.configure do |c|
 
   # MaIS API client_id and secret sent in authorization request
   c.filter_sensitive_data(FAKE_CLIENT_ID) do |interaction|
-    token_match = interaction.request.body.match(/client_id=(.{8}-.{4}-.{4}-.{4}-.{12})/)
+    token_match = interaction.request.body.match(/client_id=(\w{25})/)
     token_match&.captures&.first
   end
   c.filter_sensitive_data(FAKE_CLIENT_SECRET) do |interaction|
-    token_match = interaction.request.body.match(/client_secret=(.{8}-.{4}-.{4}-.{4}-.{12})/)
+    token_match = interaction.request.body.match(/client_secret=(\w{51})/)
     token_match&.captures&.first
   end
   # MaIS API authorization access token received from authorization request


### PR DESCRIPTION
Part of https://github.com/sul-dlss/dor-services-app/issues/5284
Fixes #108
Fixes #58

URL structures change, as well as new URL for auth vs API calls.
Will require all consumers to have new config for the token URL.

Waiting on testing/switchover

This is a breaking change, but all current consumers are now pinned to < 1

see
* https://github.com/sul-dlss/dor-services-app/pull/5289
* https://github.com/sul-dlss/happy-heron/pull/3695
* https://github.com/sul-dlss/sul_pub/pull/1781