### PR TITLE
next_page is no longer present on the last page of results

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To record new cassettes:
 2. Add your new spec with a new cassette name (or delete a previous cassette to re-create it).
 3. Run just that new spec (important: else previous specs may use cassettes that have redacted credentials, causing your new spec to fail).
 4. You should get a new cassette with the name you specified in the spec.
-5. The cassette should have access tokens and secrets sanitized by the config in `spec_helper.rb`, but you can double check.
+5. The cassette should have access tokens and secrets sanitized by the config in `spec_helper.rb`, but you can double check.  The one exception is the access_token for each ORCID user, these need to be set to "private_access_token" in the cassette manually, as VCR filter_sensitive_data can only replace the first instance.
 6. Set your configuration at the top of the spec back to the fake client_id and client_secret values.
 7. The spec that checks for a raised exception when fetching all users may need to be handcrafted in the cassette to look it raised a 500.  It's hard to get the actual URL to produce a 500 on this call.
 7. Re-run all the specs - they should pass now without making real calls.

--- a/lib/mais_orcid_client.rb
+++ b/lib/mais_orcid_client.rb
@@ -64,9 +64,8 @@ class MaisOrcidClient
                                      result[:last_updated])
         return orcid_users if limit && limit == orcid_users.size
       end
-      # Currently next is always present, even on last page. (This may be changed in future.)
       next_page = response.dig(:links, :next)
-      return orcid_users if last_page?(response[:links])
+      return orcid_users if next_page.nil? || next_page.empty?
     end
   end
   # rubocop:enable Metrics/MethodLength
@@ -112,10 +111,6 @@ class MaisOrcidClient
     path = '/users?scope=ANY'
     path += "&page_size=#{page_size}" if page_size
     path
-  end
-
-  def last_page?(links)
-    links[:self] == links[:last]
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/retrieves_users.yml
+++ b/spec/fixtures/vcr_cassettes/Mais_Client/_fetch_orcid_users/retrieves_users.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: client_id=abc123&client_secret=def456&grant_type=client_credentials
     headers:
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 27 Mar 2025 20:21:08 GMT
+      - Tue, 29 Apr 2025 21:08:03 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -29,10 +29,10 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - XSRF-TOKEN=73b0b14d-6c2d-4acf-8a66-a43a503b5f1a; Path=/; Secure; HttpOnly;
+      - XSRF-TOKEN=037b9e78-4c0e-44c1-8896-f984261e3813; Path=/; Secure; HttpOnly;
         SameSite=Lax
       X-Amz-Cognito-Request-Id:
-      - 38a61c28-8840-4b58-b67a-a17eec6e7bba
+      - 2b196a1b-a063-4e14-9977-6af3da27987d
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -51,8 +51,8 @@ http_interactions:
       - Server
     body:
       encoding: UTF-8
-      string: '{"access_token":"private_access_token","expires_in":3600,"token_type":"Bearer"}'
-  recorded_at: Thu, 27 Mar 2025 20:21:08 GMT
+      string: '{"access_token":"private_access_token","expires_in":300,"token_type":"Bearer"}'
+  recorded_at: Tue, 29 Apr 2025 21:08:03 GMT
 - request:
     method: get
     uri: https://mais.suapiuat.stanford.edu/orcid/v1/users?page_size=2&scope=ANY
@@ -74,21 +74,181 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 27 Mar 2025 20:21:09 GMT
+      - Tue, 29 Apr 2025 21:08:04 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3139'
+      - '763'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 130d2d40-f18d-424b-bc21-8cff058cb05b
+      - ce734697-4376-42f4-aa2f-685d60089a61
+      X-Sl-Asseturipath:
+      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
+      Referrer-Policy:
+      - strict-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains;
+      X-Amzn-Remapped-Content-Length:
+      - '763'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - default-src 'self'; font-src *;img-src * data:; script-src *; style-src *;
+      X-Sl-Proxy:
+      - 'false'
+      X-Sl-Clientip:
+      - 172.20.21.210
       X-Amz-Apigw-Id:
-      - IGjwTGqjvHcEtKw=
-      X-Amzn-Trace-Id:
-      - Root=1-67e5b334-07edc35a2e7541fa07742ff3
+      - JzbkMEECPHcETQQ=
+      Status:
+      - '200'
+      X-Sl-Pathinfo:
+      - ''
+      X-Content-Type-Options:
+      - nosniff
+      X-Sl-Assetpath:
+      - "/StanfordUAT/Mais/Orcid/users"
+      X-Sl-Authorized:
+      - 'true'
+      X-Amzn-Remapped-Date:
+      - Tue, 29 Apr 2025 21:08:04 GMT
     body:
       encoding: UTF-8
-      string: '{"meta":{"current_page":1,"total_records":12,"page_size":100,"total_pages":1},"results":[{"sunet_id":"tdelcont","orcid_id":"https://sandbox.orcid.org/0000-0002-4589-7232","access_token":"private_access_token","scope":["/read-limited"],"last_updated":"2021-05-07T22:11:00.000"},{"sunet_id":"jlittman","orcid_id":"https://sandbox.orcid.org/0000-0003-3437-349X","access_token":"68cf29cb-294e-4bc8-8afd-96315b06ae04","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T05:04:24.000"},{"sunet_id":"ddieckma","orcid_id":"https://sandbox.orcid.org/0000-0002-4481-5100","access_token":"f4ff7836-e1b0-4885-83f5-1909e355d017","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T09:27:54.000"},{"sunet_id":"muet","orcid_id":"https://sandbox.orcid.org/0000-0001-5226-468X","access_token":"ece59039-d70d-4ca0-ab46-f4b77801770d","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T09:46:44.000"},{"sunet_id":"amyhodge","orcid_id":"https://sandbox.orcid.org/0000-0002-4933-2837","access_token":"e7332b15-4efd-45be-a079-cfbb60397781","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-27T14:46:58.000"},{"sunet_id":"jtim","orcid_id":"https://sandbox.orcid.org/0000-0002-7262-6251","access_token":"88674490-60db-442d-90f7-c676bb1f2727","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T08:15:07.000"},{"sunet_id":"vivnwong","orcid_id":"https://sandbox.orcid.org/0000-0002-5466-7797","access_token":"709b6b08-7e60-4f7b-b7d4-4bd21d9c5618","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T09:50:14.000"},{"sunet_id":"ndushay","orcid_id":"https://sandbox.orcid.org/0000-0003-0962-2466","access_token":"191a80ba-78a8-4316-b8a9-ff3e37794597","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-06-01T10:21:10.000"},{"sunet_id":"kcasciot","orcid_id":"https://sandbox.orcid.org/0000-0002-7372-3555","access_token":"18e3b4d7-5afa-44ed-a8ba-1dce23cd9472","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-06-04T10:07:52.000"},{"sunet_id":"petucket","orcid_id":"https://sandbox.orcid.org/0000-0002-2230-4756","access_token":"22eb1288-2a84-4878-bcdb-f3ab7a4e8db2","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-10-13T11:37:46.000"},{"sunet_id":"etlouie","orcid_id":"https://sandbox.orcid.org/0000-0003-0525-7799","access_token":"5641416d-3af8-4ee9-b800-5e65ded97284","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2022-01-14T18:25:01.000"},{"sunet_id":"narmadha","orcid_id":"https://sandbox.orcid.org/0000-0001-7133-5674","access_token":"e8b02595-8672-42d9-8545-e1d92f9c1bf1","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2022-02-22T18:04:44.000"}],"links":{"self":"/users?scope=any&page_number=1&page_size=100","first":"/users?scope=any&page_number=1&page_size=100","prev":"","next":"","last":"/users?scope=any&page_number=1&page_size=100"}}'
-  recorded_at: Thu, 27 Mar 2025 20:21:08 GMT
+      string: '{"meta":{"current_page":1,"total_records":12,"page_size":2,"total_pages":6},"results":[{"sunet_id":"tdelcont","orcid_id":"https://sandbox.orcid.org/0000-0002-4589-7232","access_token":"private_access_token","scope":["/read-limited"],"last_updated":"2021-05-07T22:11:00.000"},{"sunet_id":"jlittman","orcid_id":"https://sandbox.orcid.org/0000-0003-3437-349X","access_token":"private_access_token","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T05:04:24.000"}],"links":{"self":"/users?scope=any&page_number=1&page_size=2","first":"/users?scope=any&page_number=1&page_size=2","prev":"","next":"/users?scope=any&page_number=2&page_size=2","last":"/users?scope=any&page_number=6&page_size=2"}}'
+  recorded_at: Tue, 29 Apr 2025 21:08:04 GMT
+- request:
+    method: get
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users?page_number=2&page_size=2&scope=any
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Authorization:
+      - Bearer private_bearer_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Apr 2025 21:08:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '839'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 18d862ab-c676-42c7-b525-ac982182c894
+      X-Sl-Asseturipath:
+      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
+      Referrer-Policy:
+      - strict-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains;
+      X-Amzn-Remapped-Content-Length:
+      - '839'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - default-src 'self'; font-src *;img-src * data:; script-src *; style-src *;
+      X-Sl-Proxy:
+      - 'false'
+      X-Sl-Clientip:
+      - 172.20.21.210
+      X-Amz-Apigw-Id:
+      - JzbkQHKSvHcEuAQ=
+      Status:
+      - '200'
+      X-Sl-Pathinfo:
+      - ''
+      X-Content-Type-Options:
+      - nosniff
+      X-Sl-Assetpath:
+      - "/StanfordUAT/Mais/Orcid/users"
+      X-Sl-Authorized:
+      - 'true'
+      X-Amzn-Remapped-Date:
+      - Tue, 29 Apr 2025 21:08:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"current_page":2,"total_records":12,"page_size":2,"total_pages":6},"results":[{"sunet_id":"ddieckma","orcid_id":"https://sandbox.orcid.org/0000-0002-4481-5100","access_token":"private_access_token","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T09:27:54.000"},{"sunet_id":"muet","orcid_id":"https://sandbox.orcid.org/0000-0001-5226-468X","access_token":"private_access_token","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-14T09:46:44.000"}],"links":{"self":"/users?scope=any&page_number=2&page_size=2","first":"/users?scope=any&page_number=1&page_size=2","prev":"/users?scope=any&page_number=1&page_size=2","next":"/users?scope=any&page_number=3&page_size=2","last":"/users?scope=any&page_number=6&page_size=2"}}'
+  recorded_at: Tue, 29 Apr 2025 21:08:04 GMT
+- request:
+    method: get
+    uri: https://mais.suapiuat.stanford.edu/orcid/v1/users?page_number=3&page_size=2&scope=any
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - stanford-library-sul-pub
+      Authorization:
+      - Bearer private_bearer_token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Apr 2025 21:08:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '839'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 5f499890-dffd-425d-b31f-4974eb852258
+      X-Sl-Asseturipath:
+      - "/api/1/rest/feed-master/queue/StanfordUAT/Mais/Orcid/users"
+      Referrer-Policy:
+      - strict-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains;
+      X-Amzn-Remapped-Content-Length:
+      - '839'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - default-src 'self'; font-src *;img-src * data:; script-src *; style-src *;
+      X-Sl-Proxy:
+      - 'false'
+      X-Sl-Clientip:
+      - 172.20.21.210
+      X-Amz-Apigw-Id:
+      - JzbkTHILPHcEi6w=
+      Status:
+      - '200'
+      X-Sl-Pathinfo:
+      - ''
+      X-Content-Type-Options:
+      - nosniff
+      X-Sl-Assetpath:
+      - "/StanfordUAT/Mais/Orcid/users"
+      X-Sl-Authorized:
+      - 'true'
+      X-Amzn-Remapped-Date:
+      - Tue, 29 Apr 2025 21:08:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"current_page":3,"total_records":12,"page_size":2,"total_pages":6},"results":[{"sunet_id":"amyhodge","orcid_id":"https://sandbox.orcid.org/0000-0002-4933-2837","access_token":"private_access_token","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-27T14:46:58.000"},{"sunet_id":"jtim","orcid_id":"https://sandbox.orcid.org/0000-0002-7262-6251","access_token":"private_access_token","scope":["/read-limited","/activities/update","/person/update"],"last_updated":"2021-05-28T08:15:07.000"}],"links":{"self":"/users?scope=any&page_number=3&page_size=2","first":"/users?scope=any&page_number=1&page_size=2","prev":"/users?scope=any&page_number=2&page_size=2","next":"/users?scope=any&page_number=4&page_size=2","last":"/users?scope=any&page_number=6&page_size=2"}}'
+  recorded_at: Tue, 29 Apr 2025 21:08:04 GMT
 recorded_with: VCR 6.3.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,10 @@ VCR.configure do |c|
   }
   c.configure_rspec_metadata!
 
+  # The MaIS API token in the header
+  c.filter_sensitive_data('API_TOKEN') do |interaction|
+    interaction.request.headers['Authorization']
+  end
   # MaIS API client_id and secret sent in authorization request
   c.filter_sensitive_data(FAKE_CLIENT_ID) do |interaction|
     token_match = interaction.request.body.match(/client_id=(\w{25})/)


### PR DESCRIPTION
## Why was this change made? 🤔

We can now simplify how we can check for the last page, which is the absence of the 'next_link' block.  Confirmed this now works as expected and is how we are doing in the rialto-airflow project, which implements this API in python code.

## How was this change tested? 🤨

Localhost console and CI